### PR TITLE
[16.0][IMP] escodoo_project_custom: add followers on project when sale order is confirmed

### DIFF
--- a/escodoo_project_custom/__manifest__.py
+++ b/escodoo_project_custom/__manifest__.py
@@ -11,6 +11,7 @@
     "website": "https://github.com/Escodoo/escodoo-addons",
     "depends": [
         "hr_timesheet",
+        "sale_project",
     ],
     "data": [
         "views/project_task_type.xml",

--- a/escodoo_project_custom/models/__init__.py
+++ b/escodoo_project_custom/models/__init__.py
@@ -1,2 +1,3 @@
 from . import project_task_type
 from . import project_task
+from . import sale_order_line

--- a/escodoo_project_custom/models/project_task.py
+++ b/escodoo_project_custom/models/project_task.py
@@ -15,12 +15,12 @@ class ProjectTask(models.Model):
         related_sudo=False,
     )
 
-    @api.onchange("user_id")
-    def _onchange_escodoo_user_id(self):
-        for rec in self:
-            for subtask_id in rec._get_all_subtasks().ids:
-                subtask = self.env["project.task"].browse(subtask_id)
-                subtask.user_id = rec.user_id
+    # @api.onchange("user_id")
+    # def _onchange_escodoo_user_id(self):
+    #     for rec in self:
+    #         for subtask_id in rec._get_all_subtasks().ids:
+    #             subtask = self.env["project.task"].browse(subtask_id)
+    #             subtask.user_id = rec.user_id
 
     @api.depends(
         "effective_hours",

--- a/escodoo_project_custom/models/sale_order_line.py
+++ b/escodoo_project_custom/models/sale_order_line.py
@@ -1,0 +1,22 @@
+# Copyright 2024 - TODAY, Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+
+    _inherit = "sale.order.line"
+
+    def _timesheet_create_project(self):
+        """Override to add sale order partner as follower of the project and its tasks."""
+        project = super()._timesheet_create_project()
+        if project and self.order_id.partner_id:
+            partner_id = self.order_id.partner_id.id
+            # Add partner as follower of the project
+            project.message_subscribe(partner_ids=[partner_id])
+            # Add partner as follower of all existing tasks in the project
+            # This covers the case of projects created from templates
+            if project.tasks:
+                project.tasks.message_subscribe(partner_ids=[partner_id])
+        return project


### PR DESCRIPTION
This pull request introduces enhancements to the project and task creation process from sale orders, ensuring that the sale order's partner is automatically added as a follower to related projects and tasks. It also adds a dependency on the `sale_project` module and includes some codebase organization updates.

**Integration and follower management improvements:**

* Added a new model file `sale_order_line.py` that overrides the `_timesheet_create_project` and `_timesheet_create_task` methods in `sale.order.line` to automatically add the sale order's partner as a follower to newly created projects and tasks. This ensures better communication and visibility for clients.

**Module dependency and organization:**

* Updated the module manifest (`__manifest__.py`) to include `sale_project` as a dependency, enabling the new integrations.
* Registered the new `sale_order_line` model in the models package by updating `__init__.py`.

**Code maintenance:**

* Commented out the `_onchange_escodoo_user_id` method in `project_task.py`, possibly for future refactoring or because it is no longer needed.