### PR TITLE
[16.0][FIX] escodoo_budget_simulator: ilike product_template

### DIFF
--- a/escodoo_budget_simulator/models/budget_simulation.py
+++ b/escodoo_budget_simulator/models/budget_simulation.py
@@ -4,6 +4,8 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import PRODUCT_FISCAL_TYPE_SERVICE
+
 
 class BudgetSimulation(models.Model):
     """Budget Simulation.
@@ -620,7 +622,9 @@ class BudgetSimulation(models.Model):
             [
                 ("type", "=", "service"),
                 ("sale_ok", "=", True),
-                ("name", "ilike", "hour"),
+                "|",
+                ("product_tmpl_id.name", "ilike", "horas"),
+                ("product_tmpl_id.name", "ilike", "hour"),
             ],
             limit=1,
         )
@@ -632,6 +636,7 @@ class BudgetSimulation(models.Model):
                     "type": "service",
                     "sale_ok": True,
                     "purchase_ok": False,
+                    "fiscal_type": PRODUCT_FISCAL_TYPE_SERVICE,
                 }
             )
             product = product_template.product_variant_id


### PR DESCRIPTION
@Escodoo HT01880

- Quando criar o Produto criar com o fiscal_type para pode colocar operação fiscal no produto.
- Correção do search usando o product_tmpl_id.name

Por que da forma que esta hoje nunca vai entrar nesse codigo pq o tabela product.product não tem o campo name nem o campo type
```
product = self.env["product.product"].search(
            [
                ("type", "=", "service"),
                ("sale_ok", "=", True),
                "|",
                ("product_tmpl_id.name", "ilike", "horas"),
                ("product_tmpl_id.name", "ilike", "hour"),
            ],
            limit=1,
        )
```