### PR TITLE
[16.0][IMP] escodoo_budget_simulator: project cust amount

### DIFF
--- a/escodoo_budget_simulator/models/budget_simulation.py
+++ b/escodoo_budget_simulator/models/budget_simulation.py
@@ -31,6 +31,19 @@ class BudgetSimulation(models.Model):
     _description = "Budget Simulation"
     _inherit = ["mail.thread", "mail.activity.mixin", "budget.mixin"]
     _order = "create_date desc"
+    _SUPPORT_PRODUCT_PARAM = (
+        "escodoo_budget_simulator.support_maintenance_contract_product_id"
+    )
+    _MIGRATION_PRODUCT_PARAM = "escodoo_budget_simulator.migration_contract_product_id"
+    _PROJECT_COST_PERCENT_PARAM = (
+        "escodoo_budget_simulator.default_project_cost_percent"
+    )
+    _SUPPORT_FIXED_AMOUNT_PARAM = (
+        "escodoo_budget_simulator.support_maintenance_contract_fixed_amount"
+    )
+    _MIGRATION_FIXED_AMOUNT_PARAM = (
+        "escodoo_budget_simulator.migration_contract_fixed_amount"
+    )
 
     # Fields
     name = fields.Char(
@@ -235,6 +248,61 @@ class BudgetSimulation(models.Model):
         "is confirmed, it can be converted to a sale order using the 'Create "
         "Quotation' button. This field links back to the created sale order.",
     )
+    support_contract_sale_order_id = fields.Many2one(
+        "sale.order",
+        string="Support Contract Quotation",
+        readonly=True,
+        copy=False,
+        tracking=True,
+        help="Optional support/maintenance contract quotation generated from this "
+        "simulation.",
+    )
+    migration_contract_sale_order_id = fields.Many2one(
+        "sale.order",
+        string="Migration Contract Quotation",
+        readonly=True,
+        copy=False,
+        tracking=True,
+        help="Optional migration contract quotation generated from this simulation.",
+    )
+    generate_support_contract_quotation = fields.Boolean(
+        default=False,
+        help="If enabled, creating the implementation quotation also creates "
+        "a support/maintenance contract quotation.",
+    )
+    generate_migration_contract_quotation = fields.Boolean(
+        default=False,
+        help="If enabled, creating the implementation quotation also creates "
+        "a migration contract quotation.",
+    )
+    project_cost_percent = fields.Float(
+        string="Project Cost Percentage",
+        default=lambda self: self._default_project_cost_percent(),
+        help="Percentage used to estimate project cost.",
+    )
+    project_cost_amount = fields.Float(
+        string="Project Cost",
+        compute="_compute_project_cost_amount",
+        store=True,
+        help="Estimated project cost based on the simulation total and project "
+        "cost percentage.",
+    )
+
+    @api.model
+    def _default_project_cost_percent(self):
+        value = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(self._PROJECT_COST_PERCENT_PARAM, "0.0")
+        )
+        return float(value or 0.0)
+
+    @api.depends("project_cost_percent", "sale_order_id.amount_total")
+    def _compute_project_cost_amount(self):
+        for simulation in self:
+            simulation.project_cost_amount = (
+                simulation.sale_order_id.amount_total or 0.0
+            ) * (simulation.project_cost_percent / 100.0)
 
     # Methods
     @api.model_create_multi
@@ -438,6 +506,8 @@ class BudgetSimulation(models.Model):
                 )
         if self.state in ("confirmed", "quotation", "cancelled"):
             self.state = "draft"
+            self.support_contract_sale_order_id = False
+            self.migration_contract_sale_order_id = False
         return True
 
     def action_view_quotation(self):
@@ -464,7 +534,7 @@ class BudgetSimulation(models.Model):
             "target": "current",
         }
 
-    def action_create_quotation(self):
+    def action_create_quotation(self):  # noqa: C901
         """Create sale order from confirmed simulation.
 
         This method creates a sale order from this confirmed simulation. All
@@ -583,6 +653,14 @@ class BudgetSimulation(models.Model):
         # Link sale order to simulation and update state
         self.sale_order_id = sale_order.id
         self.state = "quotation"
+        if self.generate_support_contract_quotation:
+            self.support_contract_sale_order_id = (
+                self._create_support_contract_quotation(sale_order).id
+            )
+        if self.generate_migration_contract_quotation:
+            self.migration_contract_sale_order_id = (
+                self._create_migration_contract_quotation(sale_order).id
+            )
 
         return {
             "type": "ir.actions.act_window",
@@ -592,6 +670,119 @@ class BudgetSimulation(models.Model):
             "view_mode": "form",
             "target": "current",
         }
+
+    def _create_support_contract_quotation(self, implementation_sale_order):
+        self.ensure_one()
+        return self._create_contract_quotation(
+            implementation_sale_order=implementation_sale_order,
+            product=self._get_support_maintenance_contract_product(),
+            fixed_amount=self._get_support_contract_fixed_amount(),
+            suffix=_("Support Contract"),
+            line_name=_("Support and Maintenance Contract"),
+        )
+
+    def _create_migration_contract_quotation(self, implementation_sale_order):
+        self.ensure_one()
+        return self._create_contract_quotation(
+            implementation_sale_order=implementation_sale_order,
+            product=self._get_migration_contract_product(),
+            fixed_amount=self._get_migration_contract_fixed_amount(),
+            suffix=_("Migration Contract"),
+            line_name=_("Migration Contract"),
+        )
+
+    def _create_contract_quotation(
+        self, implementation_sale_order, product, fixed_amount, suffix, line_name
+    ):
+        contract_total = fixed_amount + self._get_project_cost_from_sale_order(
+            implementation_sale_order
+        )
+        contract_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+                "company_id": self.company_id.id,
+                "client_order_ref": "%s - Support Contract" % self.name,
+                "note": self.description or "",
+            }
+        )
+        self.env["sale.order.line"].create(
+            {
+                "order_id": contract_order.id,
+                "product_id": product.id,
+                "name": line_name,
+                "product_uom_qty": 1.0,
+                "price_unit": contract_total,
+            }
+        )
+        return contract_order
+
+    def _get_project_cost_from_sale_order(self, implementation_sale_order):
+        self.ensure_one()
+        return implementation_sale_order.amount_total * (
+            self.project_cost_percent / 100.0
+        )
+
+    def _get_support_maintenance_contract_product(self):
+        product_id = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(self._SUPPORT_PRODUCT_PARAM)
+        )
+        if not product_id:
+            raise UserError(
+                _(
+                    "Please configure the support/maintenance contract product in "
+                    "Budget Simulator settings."
+                )
+            )
+        product = self.env["product.product"].browse(int(product_id))
+        if not product.exists() or product.type != "service" or not product.sale_ok:
+            raise UserError(
+                _(
+                    "The configured support/maintenance contract product is invalid. "
+                    "Please select a saleable service product."
+                )
+            )
+        return product
+
+    def _get_migration_contract_product(self):
+        product_id = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(self._MIGRATION_PRODUCT_PARAM)
+        )
+        if not product_id:
+            raise UserError(
+                _(
+                    "Please configure the migration contract product in Budget "
+                    "Simulator settings."
+                )
+            )
+        product = self.env["product.product"].browse(int(product_id))
+        if not product.exists() or product.type != "service" or not product.sale_ok:
+            raise UserError(
+                _(
+                    "The configured migration contract product is invalid. Please "
+                    "select a saleable service product."
+                )
+            )
+        return product
+
+    def _get_support_contract_fixed_amount(self):
+        value = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(self._SUPPORT_FIXED_AMOUNT_PARAM, "0.0")
+        )
+        return float(value or 0.0)
+
+    def _get_migration_contract_fixed_amount(self):
+        value = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(self._MIGRATION_FIXED_AMOUNT_PARAM, "0.0")
+        )
+        return float(value or 0.0)
 
     def _get_service_product(self):
         """Get or create a service product for hours.

--- a/escodoo_budget_simulator/models/res_config_settings.py
+++ b/escodoo_budget_simulator/models/res_config_settings.py
@@ -7,12 +7,59 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
+    _SUPPORT_PRODUCT_PARAM = (
+        "escodoo_budget_simulator.support_maintenance_contract_product_id"
+    )
+    _MIGRATION_PRODUCT_PARAM = "escodoo_budget_simulator.migration_contract_product_id"
+    _PROJECT_COST_PERCENT_PARAM = (
+        "escodoo_budget_simulator.default_project_cost_percent"
+    )
+    _SUPPORT_FIXED_AMOUNT_PARAM = (
+        "escodoo_budget_simulator.support_maintenance_contract_fixed_amount"
+    )
+    _MIGRATION_FIXED_AMOUNT_PARAM = (
+        "escodoo_budget_simulator.migration_contract_fixed_amount"
+    )
+
     quotation_product_id = fields.Many2one(
         "product.product",
         string="Default Product for Quotations",
         domain=[("type", "=", "service"), ("sale_ok", "=", True)],
+        config_parameter="escodoo_budget_simulator.default_quotation_product_id",
         help="Default product to use when creating sale orders "
         "from confirmed simulations.",
+    )
+    support_maintenance_contract_product_id = fields.Many2one(
+        "product.product",
+        string="Support/Maintenance Contract Product",
+        domain=[("type", "=", "service"), ("sale_ok", "=", True)],
+        config_parameter=_SUPPORT_PRODUCT_PARAM,
+        help="Service product used to create the support/maintenance "
+        "contract quotation from a confirmed simulation.",
+    )
+    migration_contract_product_id = fields.Many2one(
+        "product.product",
+        string="Migration Contract Product",
+        domain=[("type", "=", "service"), ("sale_ok", "=", True)],
+        config_parameter=_MIGRATION_PRODUCT_PARAM,
+        help="Service product used to create the migration contract quotation "
+        "from a confirmed simulation.",
+    )
+    default_project_cost_percent = fields.Float(
+        string="Default Project Cost Percentage",
+        config_parameter=_PROJECT_COST_PERCENT_PARAM,
+        default_model="budget.simulation",
+        help="Default percentage used to calculate project cost.",
+    )
+    support_maintenance_contract_fixed_amount = fields.Float(
+        string="Support/Maintenance Fixed Amount",
+        config_parameter=_SUPPORT_FIXED_AMOUNT_PARAM,
+        help="Fixed amount added to the support/maintenance contract quotation.",
+    )
+    migration_contract_fixed_amount = fields.Float(
+        string="Migration Fixed Amount",
+        config_parameter=_MIGRATION_FIXED_AMOUNT_PARAM,
+        help="Fixed amount added to the migration contract quotation.",
     )
 
     @api.model
@@ -22,8 +69,33 @@ class ResConfigSettings(models.TransientModel):
         product_id = IrConfigParameter.get_param(
             "escodoo_budget_simulator.default_quotation_product_id"
         )
+        support_product_id = IrConfigParameter.get_param(self._SUPPORT_PRODUCT_PARAM)
+        migration_product_id = IrConfigParameter.get_param(
+            self._MIGRATION_PRODUCT_PARAM
+        )
+        default_project_cost_percent = IrConfigParameter.get_param(
+            self._PROJECT_COST_PERCENT_PARAM
+        )
+        support_fixed_amount = IrConfigParameter.get_param(
+            self._SUPPORT_FIXED_AMOUNT_PARAM
+        )
+        migration_fixed_amount = IrConfigParameter.get_param(
+            self._MIGRATION_FIXED_AMOUNT_PARAM
+        )
         if product_id:
             res["quotation_product_id"] = int(product_id)
+        if support_product_id:
+            res["support_maintenance_contract_product_id"] = int(support_product_id)
+        if migration_product_id:
+            res["migration_contract_product_id"] = int(migration_product_id)
+        if default_project_cost_percent is not None:
+            res["default_project_cost_percent"] = float(default_project_cost_percent)
+        if support_fixed_amount is not None:
+            res["support_maintenance_contract_fixed_amount"] = float(
+                support_fixed_amount
+            )
+        if migration_fixed_amount is not None:
+            res["migration_contract_fixed_amount"] = float(migration_fixed_amount)
         return res
 
     def set_values(self):
@@ -38,4 +110,36 @@ class ResConfigSettings(models.TransientModel):
             IrConfigParameter.set_param(
                 "escodoo_budget_simulator.default_quotation_product_id", False
             )
+        if self.support_maintenance_contract_product_id:
+            IrConfigParameter.set_param(
+                self._SUPPORT_PRODUCT_PARAM,
+                self.support_maintenance_contract_product_id.id,
+            )
+        else:
+            IrConfigParameter.set_param(
+                self._SUPPORT_PRODUCT_PARAM,
+                False,
+            )
+        if self.migration_contract_product_id:
+            IrConfigParameter.set_param(
+                self._MIGRATION_PRODUCT_PARAM,
+                self.migration_contract_product_id.id,
+            )
+        else:
+            IrConfigParameter.set_param(
+                self._MIGRATION_PRODUCT_PARAM,
+                False,
+            )
+        IrConfigParameter.set_param(
+            self._PROJECT_COST_PERCENT_PARAM,
+            self.default_project_cost_percent or 0.0,
+        )
+        IrConfigParameter.set_param(
+            self._SUPPORT_FIXED_AMOUNT_PARAM,
+            self.support_maintenance_contract_fixed_amount or 0.0,
+        )
+        IrConfigParameter.set_param(
+            self._MIGRATION_FIXED_AMOUNT_PARAM,
+            self.migration_contract_fixed_amount or 0.0,
+        )
         return True

--- a/escodoo_budget_simulator/tests/test_budget_simulation.py
+++ b/escodoo_budget_simulator/tests/test_budget_simulation.py
@@ -2,9 +2,13 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import PRODUCT_FISCAL_TYPE_SERVICE
 
+
+@tagged("post_install", "-at_install")
 class TestBudgetSimulation(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -16,9 +20,68 @@ class TestBudgetSimulation(TransactionCase):
         cls.BudgetLine = cls.env["budget.line"]
         cls.BudgetSimulationLine = cls.env["budget.simulation.line"]
         cls.Partner = cls.env["res.partner"]
+        cls.ResConfigSettings = cls.env["res.config.settings"]
+        cls.ConfigParameter = cls.env["ir.config_parameter"].sudo()
 
         # Create test partner
         cls.partner = cls.Partner.create({"name": "Test Partner"})
+
+        quotation_template = cls.env["product.template"].create(
+            {
+                "name": "Quotation Hours Product",
+                "type": "service",
+                "sale_ok": True,
+                "purchase_ok": False,
+                "list_price": 100.0,
+                "fiscal_type": PRODUCT_FISCAL_TYPE_SERVICE,
+            }
+        )
+        cls.quotation_product = quotation_template.product_variant_id
+        cls.ConfigParameter.set_param(
+            "escodoo_budget_simulator.default_quotation_product_id",
+            str(cls.quotation_product.id),
+        )
+
+        support_template = cls.env["product.template"].create(
+            {
+                "name": "Support Contract Product",
+                "type": "service",
+                "sale_ok": True,
+                "purchase_ok": False,
+                "fiscal_type": PRODUCT_FISCAL_TYPE_SERVICE,
+            }
+        )
+        cls.support_product = support_template.product_variant_id
+        cls.ConfigParameter.set_param(
+            "escodoo_budget_simulator.support_maintenance_contract_product_id",
+            str(cls.support_product.id),
+        )
+        migration_template = cls.env["product.template"].create(
+            {
+                "name": "Migration Contract Product",
+                "type": "service",
+                "sale_ok": True,
+                "purchase_ok": False,
+                "fiscal_type": PRODUCT_FISCAL_TYPE_SERVICE,
+            }
+        )
+        cls.migration_product = migration_template.product_variant_id
+        cls.ConfigParameter.set_param(
+            "escodoo_budget_simulator.migration_contract_product_id",
+            str(cls.migration_product.id),
+        )
+        cls.ConfigParameter.set_param(
+            "escodoo_budget_simulator.default_project_cost_percent",
+            "12.5",
+        )
+        cls.ConfigParameter.set_param(
+            "escodoo_budget_simulator.support_maintenance_contract_fixed_amount",
+            "2000.0",
+        )
+        cls.ConfigParameter.set_param(
+            "escodoo_budget_simulator.migration_contract_fixed_amount",
+            "1500.0",
+        )
 
         # Get or create test integrations (may exist from demo data)
         cls.integration_nfe = cls.BudgetIntegration.search(
@@ -485,3 +548,177 @@ class TestBudgetSimulation(TransactionCase):
         simulation._compute_totals()
         # final_hours = 100 * 1.15 * 1.05 * 1.30 = 156.975
         self.assertAlmostEqual(simulation.total_hours, 156.98, places=2)
+
+    def test_default_project_cost_percent_from_settings(self):
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+            }
+        )
+        self.assertEqual(simulation.project_cost_percent, 12.5)
+
+    def test_settings_persist_contract_configuration(self):
+        settings = self.ResConfigSettings.create(
+            {
+                "quotation_product_id": self.quotation_product.id,
+                "support_maintenance_contract_product_id": self.support_product.id,
+                "migration_contract_product_id": self.migration_product.id,
+                "default_project_cost_percent": 7.5,
+                "support_maintenance_contract_fixed_amount": 2500.0,
+                "migration_contract_fixed_amount": 1800.0,
+            }
+        )
+        settings.set_values()
+
+        reloaded_settings = self.ResConfigSettings.create({})
+        values = reloaded_settings.get_values()
+
+        self.assertEqual(
+            values["support_maintenance_contract_product_id"], self.support_product.id
+        )
+        self.assertEqual(
+            values["migration_contract_product_id"], self.migration_product.id
+        )
+        self.assertEqual(values["default_project_cost_percent"], 7.5)
+        self.assertEqual(values["support_maintenance_contract_fixed_amount"], 2500.0)
+        self.assertEqual(values["migration_contract_fixed_amount"], 1800.0)
+
+    def test_project_cost_amount_computation(self):
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "project_cost_percent": 10.0,
+            }
+        )
+        self.BudgetSimulationLine.create(
+            {
+                "simulation_id": simulation.id,
+                "line_id": self.line_test.id,
+            }
+        )
+        simulation.action_confirm()
+        simulation.action_create_quotation()
+        simulation._compute_totals()
+        self.assertAlmostEqual(simulation.total_hours, 100.0, places=2)
+        self.assertAlmostEqual(simulation.sale_order_id.amount_total, 10000.0, places=2)
+        self.assertAlmostEqual(simulation.project_cost_amount, 1000.0, places=2)
+
+    def test_create_support_contract_quotation_when_enabled(self):
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_support_contract_quotation": True,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        simulation.action_create_quotation()
+
+        self.assertTrue(simulation.sale_order_id)
+        self.assertTrue(simulation.support_contract_sale_order_id)
+        support_line = simulation.support_contract_sale_order_id.order_line.filtered(
+            lambda line: not line.display_type
+        )
+        self.assertEqual(len(support_line), 1)
+        expected_price = 2000.0 + (simulation.sale_order_id.amount_total * 0.125)
+        self.assertAlmostEqual(support_line.price_unit, expected_price, places=2)
+
+    def test_create_migration_contract_quotation_when_enabled(self):
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_migration_contract_quotation": True,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        simulation.action_create_quotation()
+
+        self.assertTrue(simulation.sale_order_id)
+        self.assertTrue(simulation.migration_contract_sale_order_id)
+        migration_line = (
+            simulation.migration_contract_sale_order_id.order_line.filtered(
+                lambda line: not line.display_type
+            )
+        )
+        self.assertEqual(len(migration_line), 1)
+        expected_price = 1500.0 + (simulation.sale_order_id.amount_total * 0.125)
+        self.assertAlmostEqual(migration_line.price_unit, expected_price, places=2)
+
+    def test_do_not_create_support_contract_quotation_when_disabled(self):
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_support_contract_quotation": False,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        simulation.action_create_quotation()
+        self.assertFalse(simulation.support_contract_sale_order_id)
+
+    def test_do_not_create_migration_contract_quotation_when_disabled(self):
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_migration_contract_quotation": False,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        simulation.action_create_quotation()
+        self.assertFalse(simulation.migration_contract_sale_order_id)
+
+    def test_error_when_support_product_not_configured(self):
+        self.ConfigParameter.set_param(
+            "escodoo_budget_simulator.support_maintenance_contract_product_id", False
+        )
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_support_contract_quotation": True,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        with self.assertRaises(UserError):
+            simulation.action_create_quotation()
+
+    def test_error_when_migration_product_not_configured(self):
+        self.ConfigParameter.set_param(
+            "escodoo_budget_simulator.migration_contract_product_id", False
+        )
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_migration_contract_quotation": True,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        with self.assertRaises(UserError):
+            simulation.action_create_quotation()

--- a/escodoo_budget_simulator/views/budget_simulation_views.xml
+++ b/escodoo_budget_simulator/views/budget_simulation_views.xml
@@ -175,10 +175,26 @@
                                 options="{'no_create': True}"
                                 attrs="{'invisible': [('sale_order_id', '=', False)]}"
                             />
+                            <field
+                                name="support_contract_sale_order_id"
+                                readonly="1"
+                                options="{'no_create': True}"
+                                attrs="{'invisible': [('support_contract_sale_order_id', '=', False)]}"
+                            />
+                            <field
+                                name="migration_contract_sale_order_id"
+                                readonly="1"
+                                options="{'no_create': True}"
+                                attrs="{'invisible': [('migration_contract_sale_order_id', '=', False)]}"
+                            />
                         </group>
                         <group string="Pricing Parameters">
                             <field name="users_qty" string="Number of Users" />
                             <field name="company_qty" string="Number of Companies" />
+                            <field name="project_cost_percent" />
+                            <field name="project_cost_amount" readonly="1" />
+                            <field name="generate_support_contract_quotation" />
+                            <field name="generate_migration_contract_quotation" />
                             <field
                                 name="complexity"
                                 widget="radio"

--- a/escodoo_budget_simulator/views/res_config_settings_views.xml
+++ b/escodoo_budget_simulator/views/res_config_settings_views.xml
@@ -36,6 +36,99 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label
+                                    for="migration_contract_product_id"
+                                    string="Migration Contract Product"
+                                />
+                                <div class="text-muted">
+                                    Product used when generating a migration contract quotation from the simulator.
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field
+                                            name="migration_contract_product_id"
+                                            options="{'no_create': True, 'no_open': True}"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label
+                                    for="support_maintenance_contract_product_id"
+                                    string="Support/Maintenance Contract Product"
+                                />
+                                <div class="text-muted">
+                                    Product used when generating a support/maintenance contract quotation from the simulator.
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field
+                                            name="support_maintenance_contract_product_id"
+                                            options="{'no_create': True, 'no_open': True}"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label
+                                    for="default_project_cost_percent"
+                                    string="Default Project Cost Percentage"
+                                />
+                                <div class="text-muted">
+                                    Default percentage used for project cost calculations in the simulator.
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="default_project_cost_percent" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label
+                                    for="support_maintenance_contract_fixed_amount"
+                                    string="Support/Maintenance Fixed Amount"
+                                />
+                                <div class="text-muted">
+                                    Fixed amount added to the support/maintenance contract quotation.
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field
+                                            name="support_maintenance_contract_fixed_amount"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label
+                                    for="migration_contract_fixed_amount"
+                                    string="Migration Fixed Amount"
+                                />
+                                <div class="text-muted">
+                                    Fixed amount added to the migration contract quotation.
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16">
+                                        <field name="migration_contract_fixed_amount" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>

--- a/l10n_br_escodoo_budget_simulator/models/budget_simulation.py
+++ b/l10n_br_escodoo_budget_simulator/models/budget_simulation.py
@@ -9,8 +9,12 @@ class BudgetSimulation(models.Model):
 
     def action_create_quotation(self):
         res = super().action_create_quotation()
-        sale_order = self.sale_order_id
-        if not sale_order:
+        sale_orders = (
+            self.sale_order_id
+            | self.support_contract_sale_order_id
+            | self.migration_contract_sale_order_id
+        ).exists()
+        if not sale_orders:
             return res
         company = self.company_id
         fiscal_operation = (
@@ -22,8 +26,9 @@ class BudgetSimulation(models.Model):
         order_vals = {"fiscal_operation_id": fiscal_operation.id}
         if fiscal_operation.fiscal_position_id:
             order_vals["fiscal_position_id"] = fiscal_operation.fiscal_position_id.id
-        sale_order.write(order_vals)
-        lines = sale_order.order_line.filtered(lambda line: not line.display_type)
-        if lines:
-            lines.write({"fiscal_operation_id": fiscal_operation.id})
+        sale_orders.write(order_vals)
+        lines = sale_orders.mapped("order_line").filtered(
+            lambda line: not line.display_type
+        )
+        lines.write({"fiscal_operation_id": fiscal_operation.id})
         return res

--- a/l10n_br_escodoo_budget_simulator/tests/test_budget_simulation_quotation_fiscal.py
+++ b/l10n_br_escodoo_budget_simulator/tests/test_budget_simulation_quotation_fiscal.py
@@ -51,6 +51,52 @@ class TestBudgetSimulationQuotationFiscal(TransactionCase):
             "escodoo_budget_simulator.default_quotation_product_id",
             str(tmpl.product_variant_id.id),
         )
+        support_tmpl = (
+            cls.env["product.template"]
+            .with_company(cls.company)
+            .create(
+                {
+                    "name": "Budget Simulator Support Contract Product",
+                    "type": "service",
+                    "sale_ok": True,
+                    "purchase_ok": False,
+                    "fiscal_type": PRODUCT_FISCAL_TYPE_SERVICE,
+                }
+            )
+        )
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "escodoo_budget_simulator.support_maintenance_contract_product_id",
+            str(support_tmpl.product_variant_id.id),
+        )
+        migration_tmpl = (
+            cls.env["product.template"]
+            .with_company(cls.company)
+            .create(
+                {
+                    "name": "Budget Simulator Migration Contract Product",
+                    "type": "service",
+                    "sale_ok": True,
+                    "purchase_ok": False,
+                    "fiscal_type": PRODUCT_FISCAL_TYPE_SERVICE,
+                }
+            )
+        )
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "escodoo_budget_simulator.migration_contract_product_id",
+            str(migration_tmpl.product_variant_id.id),
+        )
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "escodoo_budget_simulator.default_project_cost_percent",
+            "12.5",
+        )
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "escodoo_budget_simulator.support_maintenance_contract_fixed_amount",
+            "2000.0",
+        )
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "escodoo_budget_simulator.migration_contract_fixed_amount",
+            "1500.0",
+        )
 
     def test_quotation_from_simulation_sets_fiscal_operation_and_line(self):
         """Sale order and lines get fiscal_operation_id;
@@ -116,3 +162,60 @@ class TestBudgetSimulationQuotationFiscal(TransactionCase):
 
         order = simulation.sale_order_id
         self.assertEqual(order.fiscal_operation_id, other_fo)
+
+    def test_support_contract_quotation_inherits_fiscal_operation(self):
+        self.company.write(
+            {
+                "sale_fiscal_operation_id": self.fo_venda.id,
+                "budget_simulation_fiscal_operation_id": False,
+            }
+        )
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_support_contract_quotation": True,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        simulation.action_create_quotation()
+
+        self.assertTrue(simulation.sale_order_id)
+        self.assertTrue(simulation.support_contract_sale_order_id)
+        self.assertEqual(simulation.sale_order_id.fiscal_operation_id, self.fo_venda)
+        self.assertEqual(
+            simulation.support_contract_sale_order_id.fiscal_operation_id, self.fo_venda
+        )
+
+    def test_migration_contract_quotation_inherits_fiscal_operation(self):
+        self.company.write(
+            {
+                "sale_fiscal_operation_id": self.fo_venda.id,
+                "budget_simulation_fiscal_operation_id": False,
+            }
+        )
+        simulation = self.BudgetSimulation.create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "users_qty": 5,
+                "company_qty": 1,
+                "complexity": "low",
+                "generate_migration_contract_quotation": True,
+                "module_line_ids": [(0, 0, {"module_id": self.module_sale.id})],
+            }
+        )
+        simulation.action_confirm()
+        simulation.action_create_quotation()
+
+        self.assertTrue(simulation.sale_order_id)
+        self.assertTrue(simulation.migration_contract_sale_order_id)
+        self.assertEqual(simulation.sale_order_id.fiscal_operation_id, self.fo_venda)
+        self.assertEqual(
+            simulation.migration_contract_sale_order_id.fiscal_operation_id,
+            self.fo_venda,
+        )


### PR DESCRIPTION
# Explicacao da PR 36 - `escodoo_budget_simulator`
## Objetivo
Esta PR ajusta o simulador de orcamento para que ele consiga:
- configurar produtos especificos para contratos derivados
- configurar valores fixos para suporte e migracao
- usar um percentual padrao de projeto salvo nas configuracoes
- gerar cotacoes separadas de suporte e migracao a partir da cotacao de implantacao
- calcular o custo do projeto com base no valor monetario da implantacao, e nao nas horas
## O que mudou
### 1. Novas configuracoes no `res.config.settings`
No arquivo [`escodoo_budget_simulator/models/res_config_settings.py`] foram adicionados campos para controlar a regra de negocio via configuracao:
- `support_maintenance_contract_product_id`
- `migration_contract_product_id`
- `default_project_cost_percent`
- `support_maintenance_contract_fixed_amount`
- `migration_contract_fixed_amount`
Esses campos sao persistidos em `ir.config_parameter`, entao o valor definido nas configuracoes fica disponivel para o simulador no momento de gerar as cotacoes.
Na pratica, isso permite que a area funcional altere a regra sem precisar mexer no codigo sempre que mudar:
- o produto usado no contrato de suporte
- o produto usado no contrato de migracao
- o percentual aplicado sobre a implantacao
- o valor fixo somado em cada tipo de contrato
### 2. Novos campos no simulador
No arquivo [`escodoo_budget_simulator/models/budget_simulation.py`] o modelo `budget.simulation` passou a ter:
- `support_contract_sale_order_id`
- `migration_contract_sale_order_id`
- `generate_support_contract_quotation`
- `generate_migration_contract_quotation`
Esses campos resolvem dois pontos:
1. Permitem controlar, por simulacao, se deve ou nao gerar cotacao derivada.
2. Guardam o vinculo com as cotacoes geradas, facilitando rastreabilidade.
### 3. Mudanca na logica do custo do projeto
Antes, o campo `project_cost_amount` era calculado com base em `total_hours`.
Agora ele passou a usar o valor total da cotacao de implantacao:
- formula atual: `sale_order_id.amount_total * (project_cost_percent / 100)`
Isso deixa o campo coerente com a regra de negocio, porque o percentual representa custo monetario do projeto, e nao um percentual de horas.
### 4. Geracao de duas cotacoes derivadas
Quando a cotacao principal de implantacao e criada, o simulador pode gerar mais duas cotacoes:
- contrato de suporte/manutencao
- contrato de migracao
Cada uma usa:
- um produto proprio configurado
- um valor fixo proprio configurado
- o percentual do projeto aplicado sobre o total da implantacao
As formulas ficaram assim:
- suporte: `valor_fixo_suporte + (total_implantacao * percentual / 100)`
- migracao: `valor_fixo_migracao + (total_implantacao * percentual / 100)`
Ou seja, a cotacao de implantacao continua sendo a base financeira para os contratos derivados.
### 5. Validacoes adicionadas
Se o produto configurado para suporte ou migracao nao existir, nao for servico, ou nao puder ser vendido, o sistema levanta erro antes de gerar a cotacao.
Isso evita criar pedidos inconsistentes.
### 6. Ajuste ao voltar para draft
Ao executar `action_set_draft`, o simulador agora limpa:
- `support_contract_sale_order_id`
- `migration_contract_sale_order_id`
Assim, ao reabrir a simulacao, os vinculos com cotacoes derivadas anteriores nao ficam presos indevidamente.
## Alteracoes de interface
### Configuracoes
No arquivo [`escodoo_budget_simulator/views/res_config_settings_views.xml`] foram incluidos os campos de:
- produto de migracao
- produto de suporte/manutencao
- percentual padrao do projeto
- valor fixo de suporte/manutencao
- valor fixo de migracao
### Formulario da simulacao
No arquivo [`escodoo_budget_simulator/views/budget_simulation_views.xml`] foram incluidos:
- os links para a cotacao de suporte e a de migracao
- os booleans para habilitar a geracao de cada contrato
- a exibicao de `project_cost_percent` e `project_cost_amount`
Com isso, o usuario consegue ver e controlar toda a logica diretamente pela tela.
## Localizacao fiscal brasileira
No arquivo [`l10n_br_escodoo_budget_simulator/models/budget_simulation.py`] a extensao fiscal foi ajustada para aplicar a operacao fiscal em:
- cotacao principal
- cotacao de suporte
- cotacao de migracao
Antes a logica considerava apenas a cotacao principal e a de suporte. Agora ela cobre todas as cotacoes geradas pela simulacao.
## Testes adicionados e ajustados
Os testes em [`escodoo_budget_simulator/tests/test_budget_simulation.py`] passaram a cobrir:
- persistencia das configuracoes
- percentual padrao vindo das settings
- calculo monetario de `project_cost_amount`
- geracao da cotacao de suporte
- geracao da cotacao de migracao
- nao geracao quando os flags estao desabilitados
- erro quando falta produto configurado
Os testes em [`l10n_br_escodoo_budget_simulator/tests/test_budget_simulation_quotation_fiscal.py`] passaram a cobrir tambem a heranca fiscal da cotacao de migracao.
## Resumo funcional
Depois desta PR, o fluxo ficou assim:
1. O usuario configura os produtos, valores fixos e percentual nas settings.
2. O usuario monta e confirma a simulacao.
3. O sistema cria a cotacao de implantacao.
4. Se marcado, o sistema tambem cria:
   - a cotacao de suporte
   - a cotacao de migracao
5. O valor dessas cotacoes derivadas usa a implantacao como base de calculo.
## Beneficio da alteracao
A principal melhora desta PR e transformar a regra em algo:
- configuravel
- mais aderente ao comercial
- rastreavel dentro da simulacao
- coberto por testes
Isso reduz hardcode, melhora manutencao e deixa o simulador mais proximo da regra real de precificacao.